### PR TITLE
Updated the Google Plus link with a short link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ links:
     external:     true
     publisher:    true
   - name:         Google+
-    url:          https://plus.google.com/104938615413164700753
+    url:          https://plus.google.com/+Whiskydev
     external:     true
     publisher:    true
 pygments:         true


### PR DESCRIPTION
Since we now have whiskydev.com, Google was willing to give us a Google Plus shortlink of +Whiskydev, which is kind of nice.
