### PR TITLE
Restructured the content and pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,10 +7,10 @@ facebook_appid:   # appid for like button, remove from /_includes/share.html if 
 google_analytics: UA-47125836-1 # set tracking, remove from /javascripts/basic.js if unwanted.
 
 links:
-  - name:         About
-    url:          /about/
-  - name:         Blog
+  - name:         Home
     url:          /
+  - name:         Blog
+    url:          /blog/
   - name:         Members
     url:          /members/
   - name:         Email

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,12 @@
+---
+layout: index
+---
+
+<ul class="posts">
+  {% for post in site.posts %}
+  <li>
+    <small class="datetime muted" data-time="{{ post.date }}">{{ post.date | date_to_string }} </small>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+  </li>
+  {% endfor %}
+</ul>

--- a/index.html
+++ b/index.html
@@ -2,11 +2,25 @@
 layout: index
 ---
 
+<h4>Our latest Announcement:</h4>
 <ul class="posts">
-  {% for post in site.posts %}
+  {% assign post = site.posts.first %}
   <li>
     <small class="datetime muted" data-time="{{ post.date }}">{{ post.date | date_to_string }} </small>
     <a href="{{ post.url }}">{{ post.title }}</a>
   </li>
-  {% endfor %}
 </ul>
+
+<p>
+Do you like Whisky? Do you like meeting new people? Do you like learning something new?
+</p>
+<p>
+At our events, we hope that you will be able to walk away knowing a bit more about whisky, 
+what you like, what you don’t, and maybe even pick up on a favourite new distillery.
+</p>
+<p>
+Whisky Oriented Development is more than just whisky, it is about connecting with other 
+technical people and sharing your passions.  We want it to be a comfortable place where 
+you meet other programmers from around town, learn what else is being worked on in 
+Victoria, and pick up on some cool new technologies.
+</p>


### PR DESCRIPTION
Changed the structure so that the main page has a bit more content, and a link to the latest blog entry. Blog is now it's own subdirectory, which lists all of the blog entries. The about page no longer makes sense, and has been removed. I will update this to redirect to the main page after we have the other pull request merged.
