### PR TITLE
Navigation fix

### DIFF
--- a/_includes/pages.html
+++ b/_includes/pages.html
@@ -1,14 +1,14 @@
 <section class="paging">
   {% if page.previous %}
     <div class="left">
-      <a href="{{ page.previous.url }}" title="{{ page.title }}">
+      <a href="{{ page.previous.url }}" title="{{ page.previous.title }}">
         ‹
       </a>
     </div>
   {% endif %}
   {% if page.next %}
     <div class="right">
-      <a href="{{page.next.url}}" title="{{ page.title }}">
+      <a href="{{page.next.url}}" title="{{ page.next.title }}">
         ›
       </a>
     </div>


### PR DESCRIPTION
Fixes the next and previous navigation links

On desktop, if you move your mouse to the middle left beside the posts, you should see an arrow that links to the next post. This has the same title as the current post, but for SEO, it should have the title of the post being linked to.
